### PR TITLE
Add comprehensive Salesforce callback URL documentation

### DIFF
--- a/SALESFORCE_CALLBACK_URLS.md
+++ b/SALESFORCE_CALLBACK_URLS.md
@@ -1,0 +1,75 @@
+# Salesforce Connected App Callback URLs 設定ガイド
+
+## 問題：redirect_uri_mismatch エラー
+
+### エラー内容
+```
+error=redirect_uri_mismatch&error_description=redirect_uri must match configuration
+```
+
+このエラーは、NextAuthが送信するredirect_uriがSalesforceのConnected Appに登録されていない場合に発生します。
+
+## 解決方法
+
+### 1. Salesforce Connected Appの設定を更新
+
+#### 設定手順：
+1. **Salesforce Setup** にログイン
+2. **App Manager** → 該当のConnected Appを見つける
+3. **Manage** → **Edit Policies** をクリック
+4. **OAuth Policies** セクションで **Edit** をクリック
+5. **Callback URL** フィールドに以下のURLをすべて追加：
+
+```
+http://localhost:3000/api/auth/callback/salesforce
+https://salesforce-web-app-teal.vercel.app/api/auth/callback/salesforce
+https://salesforce-web-app.vercel.app/api/auth/callback/salesforce
+https://[your-project-name].vercel.app/api/auth/callback/salesforce
+https://[your-custom-domain].com/api/auth/callback/salesforce
+```
+
+### 2. Vercelの自動生成URLについて
+
+Vercelは以下のパターンでURLを生成します：
+- **本番環境**: `https://[project-name].vercel.app`
+- **プレビュー**: `https://[project-name]-[random-string].vercel.app`
+- **ブランチ**: `https://[project-name]-[branch-name].vercel.app`
+
+すべての環境で動作させるため、想定されるURLパターンをすべて登録してください。
+
+### 3. 注意事項
+
+- URLは**完全一致**である必要があります（大文字小文字も区別されます）
+- 末尾のスラッシュの有無も重要です（通常は含めません）
+- プロトコル（http/https）も正確に一致させる必要があります
+- 保存後、変更が反映されるまで数分かかる場合があります
+
+### 4. デバッグ方法
+
+エラーが続く場合は、ブラウザの開発者ツールでネットワークタブを確認し、実際のredirect_uriパラメータを確認してください：
+
+```
+https://[salesforce-domain]/services/oauth2/authorize?
+  client_id=...&
+  redirect_uri=https://salesforce-web-app-teal.vercel.app/api/auth/callback/salesforce&
+  ...
+```
+
+この`redirect_uri`の値が、Connected Appに登録されているものと完全に一致していることを確認してください。
+
+## トラブルシューティング
+
+### よくある問題：
+
+1. **URLのタイポ**: コピー＆ペースト時のミスに注意
+2. **HTTPSとHTTPの混在**: 本番環境は必ずHTTPS
+3. **ポート番号**: localhost:3000など、ポート番号も含める
+4. **パスの相違**: `/api/auth/callback/salesforce`のパスが正確か確認
+
+### 確認コマンド：
+
+Connected Appの現在の設定を確認するには、Salesforce CLIを使用：
+
+```bash
+sfdx force:org:open -p /lightning/setup/ConnectedApplication/home
+```

--- a/SETUP.md
+++ b/SETUP.md
@@ -33,7 +33,13 @@ NODE_ENV=development
    - **API Name**: Salesforce_Web_App
    - **Contact Email**: あなたのメールアドレス
    - **Enable OAuth Settings**: チェック
-   - **Callback URL**: `http://localhost:3000/api/auth/callback`
+   - **Callback URL**: 以下のURLをすべて追加
+     ```
+     http://localhost:3000/api/auth/callback/salesforce
+     https://salesforce-web-app-teal.vercel.app/api/auth/callback/salesforce
+     https://salesforce-web-app.vercel.app/api/auth/callback/salesforce
+     https://[your-project-name].vercel.app/api/auth/callback/salesforce
+     ```
    - **Selected OAuth Scopes**:
      - Access your basic information (id, profile, email, address, phone)
      - Manage user data via APIs (api)
@@ -73,7 +79,7 @@ npm run dev
 1. **環境変数の確認**: `.env.local`ファイルの値が正しく設定されているか確認
 2. **Connected App設定**: Salesforce側のConnected App設定が正しいか確認
 3. **ドメインURL**: `SALESFORCE_INSTANCE_URL`がhttpsで始まり、末尾にスラッシュがないことを確認
-4. **コールバックURL**: Connected AppのCallback URLが`http://localhost:3000/api/auth/callback`に設定されているか確認
+4. **コールバックURL**: Connected AppのCallback URLに必要なURLがすべて登録されているか確認（開発環境とVercel環境の両方）
 
 #### よくあるエラー
 

--- a/VERCEL_SETUP.md
+++ b/VERCEL_SETUP.md
@@ -29,10 +29,28 @@ NODE_ENV=production
 
 ## Salesforce Connected App設定
 
-Salesforceで以下のCallback URLを許可してください：
+### 重要：Callback URLの設定
 
-1. 開発環境: `http://localhost:3000/api/auth/callback/salesforce`
-2. 本番環境: `https://your-vercel-app-url.vercel.app/api/auth/callback/salesforce`
+SalesforceのConnected Appで以下の**すべて**のCallback URLを許可してください：
+
+```
+http://localhost:3000/api/auth/callback/salesforce
+https://salesforce-web-app-teal.vercel.app/api/auth/callback/salesforce
+https://salesforce-web-app.vercel.app/api/auth/callback/salesforce
+https://[your-project-name].vercel.app/api/auth/callback/salesforce
+```
+
+**注意事項**：
+- Vercelの自動生成URLも含めて登録が必要です
+- プレビューデプロイメント用のURLも追加することを推奨
+- カスタムドメインを使用する場合はそのURLも追加
+
+### 設定手順：
+1. Salesforce設定 → アプリケーション → アプリケーションマネージャー
+2. 該当のConnected Appを編集
+3. 「Webアプリケーションの設定」セクション
+4. 「コールバックURL」に上記URLをすべて追加
+5. 保存
 
 ## 重要な注意事項
 


### PR DESCRIPTION
## Summary
Added comprehensive documentation for Salesforce Connected App callback URL configuration to resolve redirect_uri_mismatch errors in production.

## Problem
The error `redirect_uri_mismatch` occurs when the callback URL sent by NextAuth doesn't match any URLs registered in the Salesforce Connected App.

## Changes Made

### 1. VERCEL_SETUP.md Updates
- Added detailed callback URL configuration section
- Listed all required URLs including Vercel auto-generated URLs
- Added step-by-step configuration instructions

### 2. SETUP.md Updates
- Updated callback URL section to include all environment URLs
- Added note about Vercel deployments requiring multiple URLs

### 3. New Documentation: SALESFORCE_CALLBACK_URLS.md
- Comprehensive guide for redirect_uri_mismatch errors
- Detailed explanation of Vercel URL patterns
- Troubleshooting steps and debugging methods
- Common pitfalls and solutions

## Key Information for Users

When deploying to Vercel, you must add ALL of these URLs to your Salesforce Connected App:
```
http://localhost:3000/api/auth/callback/salesforce
https://salesforce-web-app-teal.vercel.app/api/auth/callback/salesforce
https://salesforce-web-app.vercel.app/api/auth/callback/salesforce
https://[your-project-name].vercel.app/api/auth/callback/salesforce
```

## Impact
- Resolves authentication errors in production Vercel deployments
- Provides clear guidance for multi-environment setups
- Reduces configuration-related support issues

🤖 Generated with [Claude Code](https://claude.ai/code)