### PR TITLE
feat: 活動のAPIエンドポイントとサーバーサイドレンダリングを実装

### DIFF
--- a/src/app/api/salesforce/activities/[id]/route.ts
+++ b/src/app/api/salesforce/activities/[id]/route.ts
@@ -1,0 +1,164 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+import { handleApiError } from '@/lib/api/errors'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.accessToken || !session?.instanceUrl) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    
+    // まずTaskとして取得を試みる
+    const taskFields = [
+      'Id', 'Subject', 'Status', 'Priority', 'ActivityDate', 'Description',
+      'WhatId', 'What.Name', 'What.Type', 'WhoId', 'Who.Name', 'Who.Type',
+      'OwnerId', 'Owner.Name', 'IsHighPriority', 'IsClosed',
+      'CreatedDate', 'LastModifiedDate', 'Type'
+    ].join(',')
+    
+    let response = await fetch(
+      `${session.instanceUrl}/services/data/v58.0/sobjects/Task/${id}?fields=${taskFields}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${session.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+
+    if (response.ok) {
+      const task = await response.json()
+      return NextResponse.json({ ...task, activityType: 'Task' })
+    }
+
+    // TaskでなければEventとして取得を試みる
+    const eventFields = [
+      'Id', 'Subject', 'Location', 'Description', 'ActivityDate', 'ActivityDateTime',
+      'StartDateTime', 'EndDateTime', 'DurationInMinutes',
+      'WhatId', 'What.Name', 'What.Type', 'WhoId', 'Who.Name', 'Who.Type',
+      'OwnerId', 'Owner.Name', 'IsAllDayEvent',
+      'CreatedDate', 'LastModifiedDate'
+    ].join(',')
+    
+    response = await fetch(
+      `${session.instanceUrl}/services/data/v58.0/sobjects/Event/${id}?fields=${eventFields}`,
+      {
+        headers: {
+          'Authorization': `Bearer ${session.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }
+    )
+
+    if (!response.ok) {
+      return NextResponse.json(
+        { error: 'Activity not found' },
+        { status: 404 }
+      )
+    }
+
+    const event = await response.json()
+    return NextResponse.json({ ...event, activityType: 'Event' })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.accessToken || !session?.instanceUrl) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const body = await request.json()
+    const { activityType, ...updateData } = body
+    
+    const sobjectType = activityType === 'Event' ? 'Event' : 'Task'
+    const url = `${session.instanceUrl}/services/data/v58.0/sobjects/${sobjectType}/${id}`
+    
+    const response = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        'Authorization': `Bearer ${session.accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(updateData),
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      console.error('Salesforce API error:', error)
+      return NextResponse.json(
+        { error: 'Failed to update activity' },
+        { status: response.status }
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.accessToken || !session?.instanceUrl) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { id } = await params
+    const { searchParams } = new URL(request.url)
+    const activityType = searchParams.get('type') || 'Task'
+    
+    const sobjectType = activityType === 'Event' ? 'Event' : 'Task'
+    const url = `${session.instanceUrl}/services/data/v58.0/sobjects/${sobjectType}/${id}`
+    
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        'Authorization': `Bearer ${session.accessToken}`,
+      },
+    })
+
+    if (!response.ok) {
+      const error = await response.text()
+      console.error('Salesforce API error:', error)
+      return NextResponse.json(
+        { error: 'Failed to delete activity' },
+        { status: response.status }
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}

--- a/src/app/api/salesforce/activities/list/route.ts
+++ b/src/app/api/salesforce/activities/list/route.ts
@@ -1,0 +1,92 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+import { handleApiError } from '@/lib/api/errors'
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await getServerSession(authOptions)
+    
+    if (!session?.accessToken || !session?.instanceUrl) {
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    const { searchParams } = new URL(request.url)
+    const limit = searchParams.get('limit') || '50'
+    
+    // タスクを取得
+    const taskSoql = `
+      SELECT Id, Subject, Status, Priority, ActivityDate, Description,
+             WhatId, What.Name, What.Type, WhoId, Who.Name, Who.Type,
+             OwnerId, Owner.Name, IsHighPriority, IsClosed,
+             CreatedDate, LastModifiedDate, Type
+      FROM Task
+      WHERE IsDeleted = false
+      ORDER BY ActivityDate DESC, CreatedDate DESC
+      LIMIT ${limit}
+    `
+    
+    // イベントを取得
+    const eventSoql = `
+      SELECT Id, Subject, Location, Description, ActivityDate, ActivityDateTime,
+             StartDateTime, EndDateTime, DurationInMinutes,
+             WhatId, What.Name, What.Type, WhoId, Who.Name, Who.Type,
+             OwnerId, Owner.Name, IsAllDayEvent,
+             CreatedDate, LastModifiedDate
+      FROM Event
+      WHERE IsDeleted = false
+      ORDER BY ActivityDateTime DESC, CreatedDate DESC
+      LIMIT ${limit}
+    `
+    
+    const [tasksResponse, eventsResponse] = await Promise.all([
+      fetch(`${session.instanceUrl}/services/data/v58.0/query/?q=${encodeURIComponent(taskSoql)}`, {
+        headers: {
+          'Authorization': `Bearer ${session.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      }),
+      fetch(`${session.instanceUrl}/services/data/v58.0/query/?q=${encodeURIComponent(eventSoql)}`, {
+        headers: {
+          'Authorization': `Bearer ${session.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      })
+    ])
+
+    if (!tasksResponse.ok || !eventsResponse.ok) {
+      console.error('Salesforce API error:', {
+        tasks: !tasksResponse.ok ? await tasksResponse.text() : 'OK',
+        events: !eventsResponse.ok ? await eventsResponse.text() : 'OK'
+      })
+      return NextResponse.json(
+        { error: 'Failed to fetch activities' },
+        { status: 400 }
+      )
+    }
+
+    const tasks = await tasksResponse.json()
+    const events = await eventsResponse.json()
+    
+    // タスクとイベントを統合して返す
+    const activities = [
+      ...tasks.records.map((task: any) => ({ ...task, activityType: 'Task' })),
+      ...events.records.map((event: any) => ({ ...event, activityType: 'Event' }))
+    ].sort((a, b) => {
+      const dateA = new Date(a.ActivityDate || a.ActivityDateTime || a.CreatedDate)
+      const dateB = new Date(b.ActivityDate || b.ActivityDateTime || b.CreatedDate)
+      return dateB.getTime() - dateA.getTime()
+    })
+    
+    return NextResponse.json({
+      records: activities,
+      totalSize: tasks.totalSize + events.totalSize,
+      done: tasks.done && events.done
+    })
+  } catch (error) {
+    return handleApiError(error)
+  }
+}


### PR DESCRIPTION
## Summary
- 活動詳細・一覧のAPIエンドポイントを追加
- 活動詳細・一覧ページをサーバーサイドコンポーネントに変更
- パフォーマンスとSEOの向上

## 変更内容
### 新規追加
- `/api/salesforce/activities/[id]/route.ts` - 活動詳細API
- `/api/salesforce/activities/list/route.ts` - 活動一覧API

### 更新
- `/app/dashboard/activities/[id]/page.tsx` - サーバーサイドレンダリングに変更
- `/app/dashboard/activities/page.tsx` - サーバーサイドレンダリングに変更

## Test plan
- [x] 活動一覧ページが正しく表示される
- [x] 活動詳細ページが正しく表示される
- [x] 型チェックが通る (`npm run type-check`)
- [x] リントチェックが通る (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.ai/code)