### PR TITLE
fix: TaskエンティティのTypeフィールドエラーを修正

### DIFF
--- a/src/app/api/salesforce/activities/[id]/route.ts
+++ b/src/app/api/salesforce/activities/[id]/route.ts
@@ -24,7 +24,7 @@ export async function GET(
       'Id', 'Subject', 'Status', 'Priority', 'ActivityDate', 'Description',
       'WhatId', 'What.Name', 'What.Type', 'WhoId', 'Who.Name', 'Who.Type',
       'OwnerId', 'Owner.Name', 'IsHighPriority', 'IsClosed',
-      'CreatedDate', 'LastModifiedDate', 'Type'
+      'CreatedDate', 'LastModifiedDate'
     ].join(',')
     
     let response = await fetch(

--- a/src/app/api/salesforce/activities/list/route.ts
+++ b/src/app/api/salesforce/activities/list/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
       SELECT Id, Subject, Status, Priority, ActivityDate, Description,
              WhatId, What.Name, What.Type, WhoId, Who.Name, Who.Type,
              OwnerId, Owner.Name, IsHighPriority, IsClosed,
-             CreatedDate, LastModifiedDate, Type
+             CreatedDate, LastModifiedDate
       FROM Task
       WHERE IsDeleted = false
       ORDER BY ActivityDate DESC, CreatedDate DESC


### PR DESCRIPTION
## Summary
SalesforceのTaskエンティティには標準フィールドとして`Type`が存在しないため、SOQLクエリから削除しました。

## 修正内容
- 活動一覧API (`/api/salesforce/activities/list/route.ts`) のSOQLクエリから`Type`フィールドを削除
- 活動詳細API (`/api/salesforce/activities/[id]/route.ts`) のフィールドリストから`Type`フィールドを削除

## エラー内容
```
ERROR at Row:4:Column:45
No such column 'Type' on entity 'Task'. If you are attempting to use a custom field, be sure to append the '__c' after the custom field name.
```

## Test plan
- [x] 活動一覧ページが正しく表示される
- [x] 活動詳細ページが正しく表示される
- [x] Salesforce APIエラーが発生しない

🤖 Generated with [Claude Code](https://claude.ai/code)