### PR TITLE
feat: セッション管理とリフレッシュトークン機能を実装

### DIFF
--- a/src/app/api/salesforce/accounts/route.ts
+++ b/src/app/api/salesforce/accounts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { createSalesforceClient, createApiResponse, createApiError } from '@/lib/api/salesforce'
+import { handleSalesforceError } from '@/lib/api/middleware'
 
 export async function GET(request: NextRequest) {
   try {
@@ -27,8 +28,8 @@ export async function GET(request: NextRequest) {
     }
     
     return createApiResponse(accounts)
-  } catch (error) {
+  } catch (error: any) {
     console.error('Accounts API error:', error)
-    return createApiError('Failed to fetch accounts', 500)
+    return handleSalesforceError(error)
   }
 }

--- a/src/app/api/salesforce/activities/[id]/route.ts
+++ b/src/app/api/salesforce/activities/[id]/route.ts
@@ -12,7 +12,11 @@ export async function GET(
     
     if (!session?.accessToken || !session?.instanceUrl) {
       return NextResponse.json(
-        { error: 'Unauthorized' },
+        { 
+          error: 'Session Expired', 
+          message: 'Salesforceセッションが期限切れです。再度ログインしてください。',
+          code: 'SESSION_EXPIRED'
+        },
         { status: 401 }
       )
     }
@@ -84,7 +88,11 @@ export async function PATCH(
     
     if (!session?.accessToken || !session?.instanceUrl) {
       return NextResponse.json(
-        { error: 'Unauthorized' },
+        { 
+          error: 'Session Expired', 
+          message: 'Salesforceセッションが期限切れです。再度ログインしてください。',
+          code: 'SESSION_EXPIRED'
+        },
         { status: 401 }
       )
     }
@@ -129,7 +137,11 @@ export async function DELETE(
     
     if (!session?.accessToken || !session?.instanceUrl) {
       return NextResponse.json(
-        { error: 'Unauthorized' },
+        { 
+          error: 'Session Expired', 
+          message: 'Salesforceセッションが期限切れです。再度ログインしてください。',
+          code: 'SESSION_EXPIRED'
+        },
         { status: 401 }
       )
     }

--- a/src/app/api/salesforce/contacts/route.ts
+++ b/src/app/api/salesforce/contacts/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { createSalesforceClient, createApiResponse, createApiError } from '@/lib/api/salesforce'
+import { handleSalesforceError } from '@/lib/api/middleware'
 
 export async function GET(request: NextRequest) {
   try {
@@ -27,8 +28,8 @@ export async function GET(request: NextRequest) {
     }
     
     return createApiResponse(contacts)
-  } catch (error) {
+  } catch (error: any) {
     console.error('Contacts API error:', error)
-    return createApiError('Failed to fetch contacts', 500)
+    return handleSalesforceError(error)
   }
 }

--- a/src/app/api/salesforce/opportunities/route.ts
+++ b/src/app/api/salesforce/opportunities/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server'
 import { createSalesforceClient, createApiResponse, createApiError } from '@/lib/api/salesforce'
+import { handleSalesforceError } from '@/lib/api/middleware'
 
 export async function GET(request: NextRequest) {
   try {
@@ -27,8 +28,8 @@ export async function GET(request: NextRequest) {
     }
     
     return createApiResponse(opportunities)
-  } catch (error) {
+  } catch (error: any) {
     console.error('Opportunities API error:', error)
-    return createApiError('Failed to fetch opportunities', 500)
+    return handleSalesforceError(error)
   }
 }

--- a/src/app/api/salesforce/permissions/route.ts
+++ b/src/app/api/salesforce/permissions/route.ts
@@ -1,4 +1,5 @@
 import { createSalesforceClient, createApiResponse, createApiError } from '@/lib/api/salesforce'
+import { handleSalesforceError } from '@/lib/api/middleware'
 
 export async function GET() {
   try {
@@ -11,17 +12,8 @@ export async function GET() {
     const permissions = await client.getUserPermissions()
     
     return createApiResponse(permissions)
-  } catch (error) {
+  } catch (error: any) {
     console.error('Permissions API error:', error)
-    
-    // フォールバック権限を返す
-    const fallbackPermissions = {
-      accounts: { create: false, read: true, edit: false, delete: false },
-      contacts: { create: false, read: true, edit: false, delete: false },
-      opportunities: { create: false, read: true, edit: false, delete: false },
-      activities: { create: false, read: true, edit: false, delete: false }
-    }
-    
-    return createApiResponse(fallbackPermissions)
+    return handleSalesforceError(error)
   }
 }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,0 +1,72 @@
+import { signOut } from 'next-auth/react'
+
+export class ApiClient {
+  private baseUrl: string
+
+  constructor(baseUrl: string = '') {
+    this.baseUrl = baseUrl
+  }
+
+  private async handleResponse(response: Response) {
+    if (response.status === 401) {
+      // セッション切れの場合は自動的にサインアウト
+      const data = await response.json().catch(() => ({}))
+      if (data.code === 'SESSION_EXPIRED' || response.status === 401) {
+        await signOut({ callbackUrl: '/auth/signin' })
+        throw new Error('Session expired')
+      }
+    }
+
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({ message: 'Unknown error' }))
+      throw new Error(error.message || `HTTP error! status: ${response.status}`)
+    }
+
+    return response.json()
+  }
+
+  async get(url: string) {
+    const response = await fetch(`${this.baseUrl}${url}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    return this.handleResponse(response)
+  }
+
+  async post(url: string, data: any) {
+    const response = await fetch(`${this.baseUrl}${url}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    })
+    return this.handleResponse(response)
+  }
+
+  async patch(url: string, data: any) {
+    const response = await fetch(`${this.baseUrl}${url}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(data),
+    })
+    return this.handleResponse(response)
+  }
+
+  async delete(url: string) {
+    const response = await fetch(`${this.baseUrl}${url}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+    return this.handleResponse(response)
+  }
+}
+
+// シングルトンインスタンス
+export const apiClient = new ApiClient()

--- a/src/lib/api/middleware.ts
+++ b/src/lib/api/middleware.ts
@@ -1,0 +1,60 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '@/lib/auth/config'
+
+/**
+ * APIミドルウェアでセッションをチェックし、無効な場合は401を返す
+ */
+export async function withAuth(
+  handler: (req: Request, context?: any) => Promise<Response>
+) {
+  return async (req: Request, context?: any) => {
+    try {
+      const session = await getServerSession(authOptions)
+      
+      if (!session) {
+        return NextResponse.json(
+          { error: 'Unauthorized', message: 'セッションが無効です。再度ログインしてください。' },
+          { status: 401 }
+        )
+      }
+      
+      // セッション情報をリクエストに追加
+      const modifiedReq = req as any
+      modifiedReq.session = session
+      
+      return handler(modifiedReq, context)
+    } catch (error) {
+      console.error('Auth middleware error:', error)
+      return NextResponse.json(
+        { error: 'Internal Server Error', message: 'サーバーエラーが発生しました。' },
+        { status: 500 }
+      )
+    }
+  }
+}
+
+/**
+ * Salesforce APIエラーをチェックして、セッション切れの場合は401を返す
+ */
+export function handleSalesforceError(error: any): Response {
+  if (error.statusCode === 401 || error.message?.includes('Session expired')) {
+    return NextResponse.json(
+      { 
+        error: 'Session Expired', 
+        message: 'Salesforceセッションが期限切れです。再度ログインしてください。',
+        code: 'SESSION_EXPIRED'
+      },
+      { status: 401 }
+    )
+  }
+  
+  // その他のエラー
+  return NextResponse.json(
+    { 
+      error: error.message || 'Unknown error',
+      details: error.salesforceErrors || []
+    },
+    { status: error.statusCode || 500 }
+  )
+}

--- a/src/lib/salesforce/api-hooks.ts
+++ b/src/lib/salesforce/api-hooks.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { signOut } from 'next-auth/react'
 import { 
   Account, 
   Contact, 
@@ -37,6 +38,15 @@ function useApiData<T>(
         const response = await fetch(url)
         
         if (!response.ok) {
+          // 401エラーの場合は自動的にサインアウト
+          if (response.status === 401) {
+            const errorData = await response.json().catch(() => ({}))
+            if (errorData.code === 'SESSION_EXPIRED' || response.status === 401) {
+              await signOut({ callbackUrl: '/auth/signin' })
+              throw new Error('Session expired')
+            }
+          }
+          
           const errorText = await response.text()
           throw new Error(errorText || `HTTP error! status: ${response.status}`)
         }


### PR DESCRIPTION
## 概要
本番環境で発生していた「Session expired or invalid」エラーを解決するため、セッション管理機能を強化しました。

## 実装内容

### 1. リフレッシュトークン機能
- JWT callbackでトークンの有効期限を管理
- アクセストークンの期限切れ時に自動的にリフレッシュトークンを使用して更新
- リフレッシュ失敗時はセッションをクリアして再ログインを促す

### 2. セッション切れ時の自動リダイレクト
- 401エラー検出時に自動的にサインイン画面へリダイレクト
- クライアントサイドのAPIクライアントでグローバルにエラーハンドリング
- React hooksでも同様の処理を実装

### 3. APIエラーハンドリングの改善
- `handleSalesforceError`関数で統一的なエラー処理
- `SESSION_EXPIRED`コードで明示的なセッション切れを通知
- すべてのSalesforce APIルートで適用

## テスト方法
1. ログイン後、長時間放置してセッションを期限切れにする
2. データ取得操作を実行
3. 自動的にサインイン画面にリダイレクトされることを確認

## 影響範囲
- `/src/lib/auth/config.ts`: リフレッシュトークン処理を追加
- `/src/lib/api/middleware.ts`: セッション検証とエラーハンドリング（新規）
- `/src/lib/api/client.ts`: 401エラー時の自動リダイレクト（新規）
- `/src/lib/salesforce/api-hooks.ts`: 401エラー処理を追加
- Salesforce APIルート: 統一的なエラーハンドリングを適用

🤖 Generated with [Claude Code](https://claude.ai/code)