### PR TITLE
fix: Select、編集・削除機能、UI関連の問題を修正

### DIFF
--- a/src/app/dashboard/accounts/[id]/page.tsx
+++ b/src/app/dashboard/accounts/[id]/page.tsx
@@ -31,12 +31,24 @@ export default function AccountDetailPage() {
     window.location.reload()
   }
 
-  const handleDelete = () => {
-    // TODO: Implement account deletion
+  const handleDelete = async () => {
     if (confirm('この取引先を削除してもよろしいですか？')) {
-      console.log('Delete account:', accountId)
-      // After deletion, redirect to accounts list
-      // router.push('/dashboard/accounts')
+      try {
+        const response = await fetch(`/api/salesforce/accounts/${accountId}`, {
+          method: 'DELETE',
+        })
+
+        if (!response.ok) {
+          const errorText = await response.text()
+          throw new Error(`削除に失敗しました: ${errorText}`)
+        }
+
+        // 削除成功後、取引先一覧に遷移
+        router.push('/dashboard/accounts')
+      } catch (error) {
+        console.error('Account deletion error:', error)
+        alert(error instanceof Error ? error.message : '削除中にエラーが発生しました')
+      }
     }
   }
 

--- a/src/app/dashboard/contacts/[id]/page.tsx
+++ b/src/app/dashboard/contacts/[id]/page.tsx
@@ -29,12 +29,24 @@ export default function ContactDetailPage() {
     window.location.reload()
   }
 
-  const handleDelete = () => {
-    // TODO: Implement contact deletion
+  const handleDelete = async () => {
     if (confirm('この取引先責任者を削除してもよろしいですか？')) {
-      console.log('Delete contact:', contactId)
-      // After deletion, redirect to contacts list
-      // router.push('/dashboard/contacts')
+      try {
+        const response = await fetch(`/api/salesforce/contacts/${contactId}`, {
+          method: 'DELETE',
+        })
+
+        if (!response.ok) {
+          const errorText = await response.text()
+          throw new Error(`削除に失敗しました: ${errorText}`)
+        }
+
+        // 削除成功後、取引先責任者一覧に遷移
+        router.push('/dashboard/contacts')
+      } catch (error) {
+        console.error('Contact deletion error:', error)
+        alert(error instanceof Error ? error.message : '削除中にエラーが発生しました')
+      }
     }
   }
 

--- a/src/app/dashboard/opportunities/[id]/page.tsx
+++ b/src/app/dashboard/opportunities/[id]/page.tsx
@@ -18,12 +18,24 @@ export default function OpportunityDetailPage() {
     console.log('Edit opportunity:', opportunityId)
   }
 
-  const handleDelete = () => {
-    // TODO: Implement opportunity deletion
+  const handleDelete = async () => {
     if (confirm('この商談を削除してもよろしいですか？')) {
-      console.log('Delete opportunity:', opportunityId)
-      // After deletion, redirect to opportunities list
-      // router.push('/dashboard/opportunities')
+      try {
+        const response = await fetch(`/api/salesforce/opportunities/${opportunityId}`, {
+          method: 'DELETE',
+        })
+
+        if (!response.ok) {
+          const errorText = await response.text()
+          throw new Error(`削除に失敗しました: ${errorText}`)
+        }
+
+        // 削除成功後、商談一覧に遷移
+        router.push('/dashboard/opportunities')
+      } catch (error) {
+        console.error('Opportunity deletion error:', error)
+        alert(error instanceof Error ? error.message : '削除中にエラーが発生しました')
+      }
     }
   }
 

--- a/src/components/accounts/AccountEditForm.tsx
+++ b/src/components/accounts/AccountEditForm.tsx
@@ -49,8 +49,8 @@ export function AccountEditForm({ account, onCancel, onSuccess }: AccountEditFor
         },
         body: JSON.stringify({
           Name: formData.Name,
-          Type: formData.Type || null,
-          Industry: formData.Industry || null,
+          Type: formData.Type === '__NONE__' ? null : formData.Type || null,
+          Industry: formData.Industry === '__NONE__' ? null : formData.Industry || null,
           Phone: formData.Phone || null,
           Website: formData.Website || null,
           NumberOfEmployees: formData.NumberOfEmployees ? parseInt(formData.NumberOfEmployees) : null,
@@ -123,7 +123,7 @@ export function AccountEditForm({ account, onCancel, onSuccess }: AccountEditFor
                     <SelectValue placeholder="種別を選択" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">未選択</SelectItem>
+                    <SelectItem value="__NONE__">未選択</SelectItem>
                     <SelectItem value="Prospect">見込み客</SelectItem>
                     <SelectItem value="Customer - Direct">直接顧客</SelectItem>
                     <SelectItem value="Customer - Channel">チャネル顧客</SelectItem>
@@ -141,7 +141,7 @@ export function AccountEditForm({ account, onCancel, onSuccess }: AccountEditFor
                     <SelectValue placeholder="業界を選択" />
                   </SelectTrigger>
                   <SelectContent>
-                    <SelectItem value="">未選択</SelectItem>
+                    <SelectItem value="__NONE__">未選択</SelectItem>
                     <SelectItem value="Agriculture">農業</SelectItem>
                     <SelectItem value="Apparel">アパレル</SelectItem>
                     <SelectItem value="Banking">銀行</SelectItem>

--- a/src/components/contacts/ContactCreateForm.tsx
+++ b/src/components/contacts/ContactCreateForm.tsx
@@ -261,7 +261,7 @@ export function ContactCreateForm({ accountId }: ContactCreateFormProps) {
             >
               キャンセル
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} className="bg-salesforce-blue hover:bg-salesforce-darkblue">
               {isSubmitting ? '作成中...' : '作成'}
             </Button>
           </div>

--- a/src/components/opportunities/OpportunityCreateForm.tsx
+++ b/src/components/opportunities/OpportunityCreateForm.tsx
@@ -274,7 +274,7 @@ export function OpportunityCreateForm({ accountId }: OpportunityCreateFormProps)
             >
               キャンセル
             </Button>
-            <Button type="submit" disabled={isSubmitting}>
+            <Button type="submit" disabled={isSubmitting} className="bg-salesforce-blue hover:bg-salesforce-darkblue">
               {isSubmitting ? '作成中...' : '作成'}
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- Select.ItemのvalueをRadix UI仕様に合わせて空文字列から'__NONE__'に変更してエラーを修正
- 全エンティティ（取引先、取引先責任者、商談）の削除機能を実装
- 削除成功時にリスト一覧に遷移する動作を統一
- 新規作成フォームのボタンにSalesforceブランドカラーを適用
- エラーハンドリングとユーザーフィードバックを追加

## 修正内容
### 1. Select.Itemエラー修正
- Radix UIのSelectコンポーネントでは空文字列をvalueとして使用できないため、'__NONE__'に変更
- 送信時に'__NONE__'をnullに変換する処理を追加

### 2. 削除機能実装
- 取引先（/api/salesforce/accounts/[id]）
- 取引先責任者（/api/salesforce/contacts/[id]）  
- 商談（/api/salesforce/opportunities/[id]）
- 削除成功後は対応する一覧ページに自動遷移

### 3. UIスタイル統一
- 新規作成フォームの「作成」ボタンにSalesforceブランドカラーを適用
- 統一されたユーザーエクスペリエンスを提供

## Test plan
- [ ] 取引先編集フォームのSelect項目で「未選択」を選択してもエラーが発生しないことを確認
- [ ] 取引先詳細ページで削除ボタンをクリックし、確認後に削除が実行されることを確認
- [ ] 削除成功後、取引先一覧ページに遷移することを確認
- [ ] 取引先責任者と商談でも同様の削除機能が動作することを確認
- [ ] 新規作成フォームのボタンが適切なSalesforceカラーで表示されることを確認
- [ ] 削除エラー時に適切なエラーメッセージが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)