### PR TITLE
fix: JWT認証エラーのハンドリング改善

### DIFF
--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -2,12 +2,14 @@
 
 import { signIn, getSession } from 'next-auth/react'
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { Card, CardContent, Button } from '@/components'
 
 export default function SignInPage() {
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
+  const searchParams = useSearchParams()
+  const error = searchParams.get('error')
 
   useEffect(() => {
     const checkSession = async () => {
@@ -41,6 +43,14 @@ export default function SignInPage() {
             <p className="text-gray-600">
               Salesforceアカウントでログインしてください
             </p>
+            
+            {error === 'SessionExpired' && (
+              <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-md">
+                <p className="text-sm text-yellow-800">
+                  セッションの有効期限が切れました。再度ログインしてください。
+                </p>
+              </div>
+            )}
           </div>
           
           <div className="space-y-4">

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,11 +1,11 @@
 'use client'
 
 import { signIn, getSession } from 'next-auth/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, Suspense } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { Card, CardContent, Button } from '@/components'
 
-export default function SignInPage() {
+function SignInContent() {
   const [isLoading, setIsLoading] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -70,5 +70,17 @@ export default function SignInPage() {
         </CardContent>
       </Card>
     </div>
+  )
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-gray-600">Loading...</div>
+      </div>
+    }>
+      <SignInContent />
+    </Suspense>
   )
 }

--- a/src/components/data/DashboardHome.tsx
+++ b/src/components/data/DashboardHome.tsx
@@ -6,6 +6,7 @@ import { Card, CardHeader, CardContent } from '../ui/Card'
 import { LoadingSpinner } from '../ui/LoadingSpinner'
 import { usePermissions } from '@/lib/permissions'
 import Link from 'next/link'
+import { checkApiResponse } from '@/lib/api/error-handlers'
 
 interface DashboardStats {
   accounts: number
@@ -30,8 +31,12 @@ export function DashboardHome() {
         setLoading(true)
         const response = await fetch('/api/salesforce/dashboard/stats')
         
+        // 認証エラーのチェック
+        await checkApiResponse(response)
+        
         if (!response.ok) {
-          throw new Error('Failed to fetch dashboard statistics')
+          const errorData = await response.json()
+          throw new Error(errorData.message || 'Failed to fetch dashboard statistics')
         }
         
         const data = await response.json()

--- a/src/lib/api/error-handlers.ts
+++ b/src/lib/api/error-handlers.ts
@@ -1,0 +1,39 @@
+import { signOut } from 'next-auth/react'
+
+export interface ApiError {
+  error: string
+  message: string
+  code?: string
+  details?: any[]
+  statusCode?: number
+}
+
+/**
+ * APIエラーをチェックして、認証エラーの場合は自動的にサインアウトする
+ */
+export async function handleApiError(error: ApiError): Promise<void> {
+  // JWT認証エラーまたはセッション切れの場合
+  if (
+    error.code === 'INVALID_JWT_FORMAT' || 
+    error.code === 'SESSION_EXPIRED' ||
+    error.statusCode === 401
+  ) {
+    console.error('Authentication error detected:', error)
+    
+    // サインアウトしてログインページにリダイレクト
+    await signOut({ 
+      callbackUrl: '/auth/signin?error=SessionExpired',
+      redirect: true 
+    })
+  }
+}
+
+/**
+ * APIレスポンスをチェックして、エラーがある場合は処理する
+ */
+export async function checkApiResponse(response: Response): Promise<void> {
+  if (!response.ok && response.status === 401) {
+    const errorData = await response.json() as ApiError
+    await handleApiError(errorData)
+  }
+}

--- a/src/lib/api/salesforce.ts
+++ b/src/lib/api/salesforce.ts
@@ -17,6 +17,12 @@ export async function createSalesforceClient(): Promise<SalesforceClient | null>
       return null
     }
 
+    // セッションエラーがある場合は null を返す
+    if ((session as any).error === 'RefreshAccessTokenError') {
+      console.error('Session has refresh token error')
+      return null
+    }
+
     return new SalesforceClient(
       session.instanceUrl,
       session.accessToken


### PR DESCRIPTION
## Summary
- JWT認証エラー（INVALID_JWT_FORMAT）を適切に処理するための改善を実装
- 認証エラー時に自動的にサインアウトして再ログインを促すフローを追加

## 変更内容
- JWT認証エラーの検出と処理を`handleSalesforceError`に追加
- エラーハンドリング専用のユーティリティファイル`error-handlers.ts`を作成
- ダッシュボードでAPIエラーを適切に処理し、401エラー時に自動サインアウト
- サインインページでセッション切れメッセージを表示
- `useSearchParams`をSuspenseでラップしてNext.jsの警告を解消

## Test plan
- [ ] JWT認証エラーが発生した際に、自動的にサインアウトされることを確認
- [ ] サインインページでセッション切れメッセージが表示されることを確認
- [ ] 通常の認証フローが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)